### PR TITLE
Twice prepended $shcmd in $rhost for getsnapsfallback

### DIFF
--- a/syncoid
+++ b/syncoid
@@ -1596,12 +1596,6 @@ sub getsnapsfallback() {
 	my $fsescaped = escapeshellparam($fs);
 	if ($isroot) { $mysudocmd = ''; } else { $mysudocmd = $sudocmd; }
 
-	if ($rhost ne '') {
-		$rhost = "$sshcmd $rhost";
-		# double escaping needed
-		$fsescaped = escapeshellparam($fsescaped);
-	}
-
 	my $getsnapcmd = "$rhost $mysudocmd $zfscmd get -Hpd 1 type,guid,creation $fsescaped |";
 	warn "snapshot listing failed, trying fallback command";
 	if ($debug) { print "DEBUG: FALLBACK, getting list of snapshots on $fs using $getsnapcmd...\n"; }


### PR DESCRIPTION
getsnapsfallback is only called from within getsnaps if an error is detected in the command. The block:

if ($rhost ne '') {
$rhost = "$sshcmd $rhost";
# double escaping needed
$fsescaped = escapeshellparam($fsescaped);
}

Is used in both functions getsnapsfallback and getsnaps. The issue is that syncoid executes this block once in getsnaps, then when passed to getsnapsfallback it is always executed again on $rhost (as it is impossible for $rhost to be null at entry) causing the $sshcmd to be prepended twice to the command string, permanently breaking this function for all hosts that failed getsnaps.

As this block will have already been executed by getsnaps, and getsnapsfallback isn't called anywhere else in the program I am proposing removing the duplicate block from getsnapsfallback instead of writing tests here. Any additional tests/checks should be written into the main block to be inherited into this child call. Tested and validated remote send/recv execution on Solaris (5.10 10/09 -> 5.11 11.4).